### PR TITLE
Fix: Add react and react-dom to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "nodemailer": "^6.9.1"
+    "nodemailer": "^6.9.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0",


### PR DESCRIPTION
- Added `react` and `react-dom` (version ^18.2.0) to `dependencies` in `package.json`. These were missing and caused the `Can't resolve 'react-dom/client'` error during the build process.

This commit aims to fix the module resolution error and allow the build to complete successfully for deploying the static frontend to aihubservices.org.