### PR TITLE
Fix: Add bootstrap and react-router-dom to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "express": "^4.18.2",
     "nodemailer": "^6.9.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "bootstrap": "^5.3.0",
+    "react-router-dom": "^6.10.0"
   },
   "devDependencies": {
     "gh-pages": "^6.3.0",


### PR DESCRIPTION
- Added `bootstrap` (^5.3.0) and `react-router-dom` (^6.10.0) to `dependencies` in `package.json`.
- `bootstrap` was missing, causing a "Module not found" error for its CSS.
- `react-router-dom` was used in the application but not listed as a dependency.

This commit aims to fix the module resolution errors and allow the build to complete successfully for deploying your static frontend to aihubservices.org.